### PR TITLE
Add WooCommerce wallet plugin

### DIFF
--- a/wc-wallet/README.md
+++ b/wc-wallet/README.md
@@ -1,0 +1,12 @@
+# WooCommerce Custom Wallet
+
+This simple plugin provides a wallet system for WooCommerce.
+Users can deposit funds using PayPal and pay for orders using their balance.
+
+## Features
+- Stores user wallet balance in user meta.
+- Provides a `[wallet_deposit]` shortcode for creating a balance top-up form that uses PayPal exclusively.
+- Adds a `Wallet Balance` payment gateway for paying with stored balance.
+- Hides PayPal from the normal checkout page but keeps it on the deposit page.
+
+Install the plugin as usual by copying the `wc-wallet` folder into your WordPress plugins directory and activating it.

--- a/wc-wallet/includes/class-wc-gateway-wallet.php
+++ b/wc-wallet/includes/class-wc-gateway-wallet.php
@@ -1,0 +1,47 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WC_Gateway_Wallet extends WC_Payment_Gateway {
+
+    public function __construct() {
+        $this->id                 = 'wallet';
+        $this->method_title       = __( 'Wallet Balance', 'wc-wallet' );
+        $this->method_description = __( 'Pay using your wallet balance.', 'wc-wallet' );
+        $this->has_fields         = false;
+        $this->supports           = [ 'products' ];
+
+        $this->title = __( 'Wallet Balance', 'wc-wallet' );
+
+        add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
+    }
+
+    public function is_available() {
+        if ( ! is_user_logged_in() ) {
+            return false;
+        }
+        $balance = WC_Custom_Wallet::get_balance();
+        return $balance > 0;
+    }
+
+    public function process_payment( $order_id ) {
+        $order   = wc_get_order( $order_id );
+        $total   = (float) $order->get_total();
+        $balance = WC_Custom_Wallet::get_balance( $order->get_user_id() );
+
+        if ( $balance < $total ) {
+            wc_add_notice( __( 'Insufficient wallet balance.', 'wc-wallet' ), 'error' );
+            return false;
+        }
+
+        WC_Custom_Wallet::deduct_balance( $total, $order->get_user_id() );
+        $order->payment_complete();
+        $order->add_order_note( __( 'Paid using wallet balance.', 'wc-wallet' ) );
+
+        return [
+            'result'   => 'success',
+            'redirect' => $this->get_return_url( $order ),
+        ];
+    }
+}

--- a/wc-wallet/wc-wallet.php
+++ b/wc-wallet/wc-wallet.php
@@ -1,0 +1,111 @@
+<?php
+/*
+Plugin Name: WooCommerce Custom Wallet
+Description: Adds a simple wallet system allowing users to deposit via PayPal and pay orders using balance.
+Version: 1.0.0
+Author: AutoGPT
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+class WC_Custom_Wallet {
+    const META_KEY = 'wc_wallet_balance';
+
+    public static function init() {
+        add_action( 'plugins_loaded', [ __CLASS__, 'includes' ] );
+        add_filter( 'woocommerce_payment_gateways', [ __CLASS__, 'add_gateway' ] );
+        add_action( 'woocommerce_order_status_completed', [ __CLASS__, 'handle_topup_order' ] );
+        add_filter( 'woocommerce_available_payment_gateways', [ __CLASS__, 'filter_gateways' ] );
+        add_shortcode( 'wallet_deposit', [ __CLASS__, 'deposit_shortcode' ] );
+    }
+
+    public static function includes() {
+        require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-gateway-wallet.php';
+    }
+
+    public static function add_gateway( $gateways ) {
+        $gateways[] = 'WC_Gateway_Wallet';
+        return $gateways;
+    }
+
+    public static function get_balance( $user_id = 0 ) {
+        $user_id = $user_id ? $user_id : get_current_user_id();
+        return (float) get_user_meta( $user_id, self::META_KEY, true );
+    }
+
+    public static function add_balance( $amount, $user_id = 0 ) {
+        $user_id = $user_id ? $user_id : get_current_user_id();
+        $balance = self::get_balance( $user_id );
+        $balance += $amount;
+        update_user_meta( $user_id, self::META_KEY, $balance );
+    }
+
+    public static function deduct_balance( $amount, $user_id = 0 ) {
+        $user_id = $user_id ? $user_id : get_current_user_id();
+        $balance = self::get_balance( $user_id );
+        $balance -= $amount;
+        if ( $balance < 0 ) {
+            $balance = 0;
+        }
+        update_user_meta( $user_id, self::META_KEY, $balance );
+    }
+
+    // Handle orders created from the deposit page
+    public static function handle_topup_order( $order_id ) {
+        $order = wc_get_order( $order_id );
+        if ( $order && $order->get_meta( '_wallet_topup' ) ) {
+            $amount = (float) $order->get_total();
+            self::add_balance( $amount, $order->get_user_id() );
+        }
+    }
+
+    // Hide PayPal on checkout, unless on deposit page
+    public static function filter_gateways( $gateways ) {
+        if ( is_checkout() && ! self::is_deposit_page() ) {
+            unset( $gateways['paypal'] );
+        }
+        if ( self::is_deposit_page() ) {
+            foreach ( $gateways as $id => $gateway ) {
+                if ( 'paypal' !== $id ) {
+                    unset( $gateways[ $id ] );
+                }
+            }
+        }
+        return $gateways;
+    }
+
+    public static function is_deposit_page() {
+        return is_page() && has_shortcode( get_post()->post_content, 'wallet_deposit' );
+    }
+
+    public static function deposit_shortcode() {
+        if ( ! is_user_logged_in() ) {
+            return __( 'You need to log in to deposit funds.', 'wc-wallet' );
+        }
+        ob_start();
+        ?>
+        <form method="post">
+            <p>
+                <label><?php _e( 'Deposit amount', 'wc-wallet' ); ?></label>
+                <input type="number" name="wallet_amount" min="1" step="0.01" required />
+            </p>
+            <button type="submit" name="wallet_deposit_submit"><?php _e( 'Add to Balance via PayPal', 'wc-wallet' ); ?></button>
+        </form>
+        <?php
+        if ( isset( $_POST['wallet_deposit_submit'] ) && isset( $_POST['wallet_amount'] ) ) {
+            $amount = floatval( $_POST['wallet_amount'] );
+            $order  = wc_create_order();
+            $order->add_product( wc_get_product( 0 ), 1 );
+            $order->set_total( $amount );
+            $order->set_customer_id( get_current_user_id() );
+            $order->update_meta_data( '_wallet_topup', true );
+            $order->save();
+            wc_add_notice( __( 'Top-up order created. Please complete payment.', 'wc-wallet' ) );
+            return wc_get_checkout_url() . '?order_id=' . $order->get_id();
+        }
+        return ob_get_clean();
+    }
+}
+WC_Custom_Wallet::init();


### PR DESCRIPTION
## Summary
- add `wc-wallet` plugin with custom wallet gateway and shortcode

## Testing
- `pre-commit run --files wc-wallet/wc-wallet.php wc-wallet/includes/class-wc-gateway-wallet.php` *(fails: command not found)*
- `pytest` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68505153eeac8332945a32deaed13562